### PR TITLE
fix : artist 엔티티 수정에 따른 아티스트 생성/조회 조건 수정

### DIFF
--- a/final_project_backend/src/admin/dto/create-artist.dto.ts
+++ b/final_project_backend/src/admin/dto/create-artist.dto.ts
@@ -1,8 +1,13 @@
 import { PickType } from '@nestjs/swagger';
 import { Artist } from '../entities/artist.entity';
+import { IsNotEmpty, IsNumber } from 'class-validator';
+import { MESSAGES } from 'src/constants/message.constant';
 
 export class CreateArtistDto extends PickType(Artist, [
   'communityId',
-  'communityUserId',
   'artistNickname',
-]) {}
+]) {
+  @IsNotEmpty({ message: MESSAGES.AUTH.COMMON.COMMUNITY_USER.NO_USER })
+  @IsNumber()
+  userId: number;
+}

--- a/final_project_backend/src/admin/services/admin-artist.service.ts
+++ b/final_project_backend/src/admin/services/admin-artist.service.ts
@@ -84,7 +84,7 @@ export class AdminArtistService {
     return true;
   }
 
-  async findByCommunityIdAndUserId(communityUserId: number) {
+  async findByCommunityUserId(communityUserId: number) {
     const existedArtist = await this.artistRepository.findOneBy({
       communityUserId,
     });

--- a/final_project_backend/src/auth/guards/community-user.guard.ts
+++ b/final_project_backend/src/auth/guards/community-user.guard.ts
@@ -65,8 +65,8 @@ export class CommunityUserGuard implements CanActivate {
     if (roles.includes(CommunityUserRole.ARTIST)) {
       try {
         const artistInfo =
-          this.artistService.findByCommunityIdAndUserId(communityUserId);
-        request.user.role = artistInfo;
+          await this.artistService.findByCommunityIdAndUserId(communityUserId);
+        request.user.roleInfo = artistInfo;
         hasRole = true;
       } catch (e) {}
     }

--- a/final_project_backend/src/auth/guards/community-user.guard.ts
+++ b/final_project_backend/src/auth/guards/community-user.guard.ts
@@ -65,7 +65,7 @@ export class CommunityUserGuard implements CanActivate {
     if (roles.includes(CommunityUserRole.ARTIST)) {
       try {
         const artistInfo =
-          await this.artistService.findByCommunityIdAndUserId(communityUserId);
+          await this.artistService.findByCommunityUserId(communityUserId);
         request.user.roleInfo = artistInfo;
         hasRole = true;
       } catch (e) {}

--- a/final_project_backend/src/auth/guards/community-user.guard.ts
+++ b/final_project_backend/src/auth/guards/community-user.guard.ts
@@ -37,7 +37,7 @@ export class CommunityUserGuard implements CanActivate {
     const userId = request.user?.id;
     let { communityId } = request.body;
     if (request?.params?.communityId) communityId = request.params.communityId;
-    console.log(request.params);
+
     if (!userId) {
       throw new NotFoundException(MESSAGES.AUTH.COMMON.COMMUNITY_USER.NO_USER);
     }
@@ -48,25 +48,25 @@ export class CommunityUserGuard implements CanActivate {
       );
     }
 
-    // Roles 지정하지 않을 경우 communityUser만 검사
-    if (_.isEmpty(roles)) {
+    const existedCommunityUser =
       await this.communityUserService.findByCommunityIdAndUserId(
         communityId,
         userId,
       );
+
+    // Roles 지정하지 않을 경우 communityUser만 검사
+    if (_.isEmpty(roles) && existedCommunityUser) {
       return true;
     }
 
     // Roles 설정시 Roles(ARIST,MANAGER) + communityUser 검사
-
     let hasRole = false;
-    console.log;
+    const communityUserId = existedCommunityUser.communityUserId;
     if (roles.includes(CommunityUserRole.ARTIST)) {
       try {
-        await this.artistService.findByCommunityIdAndUserId(
-          communityId,
-          userId,
-        );
+        const artistInfo =
+          this.artistService.findByCommunityIdAndUserId(communityUserId);
+        request.user.role = artistInfo;
         hasRole = true;
       } catch (e) {}
     }

--- a/final_project_backend/src/user/interfaces/partial-user.entity.ts
+++ b/final_project_backend/src/user/interfaces/partial-user.entity.ts
@@ -1,3 +1,6 @@
+import { CommunityUserRole } from 'src/community/community-user/types/community-user-role.type';
+
 export interface PartialUser {
   id: number;
+  roleInfo: { roleId: number; role: CommunityUserRole };
 }


### PR DESCRIPTION
 **artist 엔티티 수정에 따른 아티스트 생성/조회 조건 수정**

**구현 내용**
- (프론트) 아티스트 생성시 communityUserId는 아직 존재하지 않기 때문에 dto로 userId를 받도록 수정
- (내부로직) 기존 아티스트 생성 후 커뮤니티 유저 생성 -> 현재 커뮤니티 유저 생성 후 아티스트 유저 생성 하도록 순서 변경
- @CommunityUserRoles 지정 & CommunityUserGuard 사용 후 req.user 를 가져올 경우 roleInfo안에 본인의 롤 정보 담도록 수정( 아래 @userInfo 내부 정보 참고 )

@userInfo() user : PartialUser 사용시 내부
```
{
  id: 3,
  role: { roleId: 1, role: 'ARTIST' }
}
```