### PR TITLE
fix : 상품 장바구니 추가시 cart_id 조회 로직 포함

### DIFF
--- a/final_project_backend/src/cart/cart.service.ts
+++ b/final_project_backend/src/cart/cart.service.ts
@@ -89,12 +89,14 @@ export class CartService {
       if (!cart) {
         cart = await queryRunner.manager.save(Cart, { user });
       }
+
       console.log('---------------장바구니생성완료------------');
       // 장바구니에 입력한 동일 상품 id && 옵션 id 있는지 확인
       const merchandiseCheck = await queryRunner.manager.findOne(CartItem, {
         where: {
           merchandise: { merchandiseId: createCartDto.merchandiseId },
           merchandiseOption: { id: createCartDto.merchandiseOptionId },
+          cartId: cart.id,
         },
         relations: ['merchandise', 'merchandiseOption'],
       });
@@ -227,18 +229,18 @@ export class CartService {
     console.log(cartItem);
     console.log(quantity);
     let updatedQuantity;
-    if (quantity==UpdateQuantity.INCREMENT) {
+    if (quantity == UpdateQuantity.INCREMENT) {
       updatedQuantity = cartItem.quantity + 1;
-    } else if (quantity==UpdateQuantity.DECREMENT) {
+    } else if (quantity == UpdateQuantity.DECREMENT) {
       updatedQuantity = cartItem.quantity - 1;
     } else {
-      return{
+      return {
         status: HttpStatus.BAD_REQUEST,
         message: '잘못된 경로입니다.',
       };
     }
-    if (updatedQuantity==0) {
-      return{
+    if (updatedQuantity == 0) {
+      return {
         status: HttpStatus.BAD_REQUEST,
         message: '최소 수량입니다.',
       };

--- a/final_project_backend/src/cart/entities/cart.item.entity.ts
+++ b/final_project_backend/src/cart/entities/cart.item.entity.ts
@@ -15,23 +15,24 @@ import { MerchandiseOption } from 'src/merchandise/entities/marchandise-option.e
 
 @Entity('cart_items')
 export class CartItem {
-  @PrimaryGeneratedColumn({ unsigned: true})
+  @PrimaryGeneratedColumn({ unsigned: true })
   id: number;
 
-  @Column({unsigned: true})
+  @Column({ unsigned: true })
   merchandiseId: number;
+
+  @Column({ unsigned: true })
+  cartId: number;
 
   // 카트 연결
   @ManyToOne(() => Cart, (cart) => cart.cartItem, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'cart_id' })
-  cart: Cart; 
+  cart: Cart;
 
   //상품 연결
-  @ManyToOne(
-    () => Merchandise,
-    (merchandise) => merchandise.cartItems,
-    { onDelete: 'CASCADE' },
-  )
+  @ManyToOne(() => Merchandise, (merchandise) => merchandise.cartItems, {
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'merchandise_id' })
   merchandise: Merchandise;
 


### PR DESCRIPTION
**문제 상황**
- 장바구니에 아이템 추가 후 장바구니 목록 조회시 새로 추가된 아이템 나타나지 않음

**원인**
- 장바구니 아이템 추가시, 카트별 아이템을 조회하는 것이 아닌 단순 아이템 조회를 하는 것으로 파악

**구현 내용**
- 장바구니 아이템 추가시 해당 장바구니에, 아이템 id, 아이템 옵션이 있는지 확인
- 해당 장바구니인지 조회하는 로직 추가

----


**수정 전** 
- 장바구니 아이템 추가시 해당 테이블에 아이템 id, 아이템 옵션이 있는지 체크해 아이템 추가 OR 개수 증가 
- 해당 장바구니의 아이템 조회가 아닌, 테이블의 아이템 조회됨

**수정 후** 
- 해당 장바구니에 해당 아이템이 있는지 확인